### PR TITLE
Add support for the tokio-postgres crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-service"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["Charles Samuels <charles@derkarl.org>"]
 description = "Parse Postgres service configuration files"
 documentation = "https://github.com/njaard/postgres-service/blob/master/Readme.md"
@@ -13,3 +13,4 @@ edition="2018"
 [dependencies]
 rust-ini = "0.17"
 postgres = { version="^0.19", default-features=false }
+tokio-postgres = "0.7.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! Parse Postgres service configuration files
 
-#![feature(doc_cfg)]
-
 use ini::Properties;
 
 fn build_from_section(section: &Properties) -> tokio_postgres::config::Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,73 +1,77 @@
-use ini::Ini;
+//! Parse Postgres service configuration files
+
+#![feature(doc_cfg)]
+
 use ini::Properties;
-use postgres::config::Config;
 
-fn build_from_section(section: &Properties)
-	-> Config
-{
-	let mut username: Option<String> = None;
-	let mut password: Option<String> = None;
+fn build_from_section(section: &Properties) -> tokio_postgres::config::Config {
+    let mut username: Option<String> = None;
+    let mut password: Option<String> = None;
 
-	let mut builder = Config::new();
-	let mut options = String::new();
+    let mut builder = tokio_postgres::config::Config::new();
+    let mut options = String::new();
 
-	for (k,v) in section.iter()
-	{
-		match k
-		{
-			"host" =>
-				{ builder.host(v); },
-			"hostaddr" => 
-				{ builder.host(v); },
-			"port" =>
-				{ builder.port(v.parse().unwrap()); },
-			"dbname" =>
-				{ builder.dbname(v); },
-			"user" =>
-				username = Some(v.to_owned()),
-			"password" =>
-				password = Some(v.to_owned()),
-			_ =>
-				options += &format!("{}={} ", k, v),
-		}
-	}
+    for (k, v) in section.iter() {
+        match k {
+            "host" => {
+                builder.host(v);
+            }
+            "hostaddr" => {
+                builder.host(v);
+            }
+            "port" => {
+                builder.port(v.parse().unwrap());
+            }
+            "dbname" => {
+                builder.dbname(v);
+            }
+            "user" => username = Some(v.to_owned()),
+            "password" => password = Some(v.to_owned()),
+            _ => options += &format!("{}={} ", k, v),
+        }
+    }
 
-	if !options.is_empty()
-		{ builder.options(&options); }
+    if !options.is_empty() {
+        builder.options(&options);
+    }
 
-	if let Some(username) = username
-		{ builder.user(&username); }
-	if let Some(password) = password
-		{ builder.password(&password); }
+    if let Some(username) = username {
+        builder.user(&username);
+    }
+    if let Some(password) = password {
+        builder.password(&password);
+    }
 
-	builder
+    builder
 }
 
-pub fn load_connect_params(
-	service_name : &str
-) -> Option<Config>
-{
-	if let Ok(home) = std::env::var("HOME")
-	{
-		if let Ok(ini) = Ini::load_from_file(home + "/" + ".pg_service.conf")
-		{
-			if let Some(section) = ini.section(Some(service_name.clone()))
-			{
-				return Some(build_from_section(section));
-			}
-		}
-	}
-
-	let confdir = std::env::var("PGSYSCONFDIR").unwrap_or("/etc/postgresql-common".into());
-
-	if let Ok(ini) = Ini::load_from_file(confdir + "/" + "pg_service.conf")
-	{
-		if let Some(section) = ini.section(Some(service_name))
-		{
-			return Some(build_from_section(section));
-		}
-	}
-
-	None
+/// Load connection parameters for the named Postgresql service
+pub fn load_connect_params(service_name: &str) -> Option<postgres::config::Config> {
+    tokio::load_connect_params(service_name).map(Into::into)
 }
 
+/// For use with tokio-postgres
+pub mod tokio {
+    use crate::build_from_section;
+    use ini::Ini;
+    /// Load connection parameters for the named Postgresql service
+    pub fn load_connect_params(service_name: &str) -> Option<tokio_postgres::config::Config> {
+        if let Ok(home) = std::env::var("HOME") {
+            if let Ok(ini) = Ini::load_from_file(home + "/" + ".pg_service.conf") {
+                if let Some(section) = ini.section(Some(service_name.clone())) {
+                    return Some(build_from_section(section));
+                }
+            }
+        }
+
+        let confdir = std::env::var("PGSYSCONFDIR").unwrap_or("/etc/postgresql-common".into());
+
+        if let Ok(ini) = Ini::load_from_file(confdir + "/" + "pg_service.conf") {
+            if let Some(section) = ini.section(Some(service_name)) {
+                return Some(build_from_section(section));
+            }
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
The tokio-postgres crate has a different Config type, so add a second
function for getting it.

Probably we could do something clever with generics, but for now copy
and paste is simpler.